### PR TITLE
Add missing dependency on seq.el

### DIFF
--- a/use-package-company.el
+++ b/use-package-company.el
@@ -23,6 +23,7 @@
 
 (require 'use-package-core)
 (require 'derived)
+(require 'seq)
 
 ;;;###autoload
 (defun use-package-company-normalize (name keyword args)

--- a/use-package-company.el
+++ b/use-package-company.el
@@ -7,7 +7,7 @@
 ;; URL: http://github.com/foltik/use-package-company/
 ;; Created: 6 Feb 2019
 ;; Version: 1.0
-;; Package-Requires: ((emacs "24.3") (use-package "2.4") (company "0.9.9"))
+;; Package-Requires: ((emacs "24.3") (use-package "2.4") (company "0.9.9") (seq "2.20"))
 ;; Keywords: convenience extensions use-package
 
 ;;; License:


### PR DESCRIPTION
This library fails to load if `seq.el` is not loaded before `seq-subseq` is called.

Also note that `seq.el` wasn't part of Emacs until Emacs 25, so you'll have to add it to the package header.
